### PR TITLE
ci(github_actions): add github_token instead of username, email

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -20,6 +20,7 @@ jobs:
               run: npm ci --dev
 
             - name: Run deploy script
+              with:
+                GITHUB_TOKEN: ${{ secrets.GH_PAGES_GITHUB_TOKEN }}
               run: |
-                git config user.name ${{secrets.GH_PAGES_USER}} && git config user.email ${{secrets.GH_PAGES_MAIL}}
                 npm run deploy


### PR DESCRIPTION
Please remember the / Bitte beachte die [Contribution Guidelines](https://github.com/FUB-HCC/20-SWP-CodingOpenness/blob/master/CONTRIBUTION.md) :heart:

## What does this PR do?

- Remove username and email and use a Github token for the gh-pages push

<!-- Concise description of what this PR achieves, including any context. -->

## Recommendations for testing

<!-- Tips for testing this PR, or anything you want to bring special attention to. -->

## Links to relevant issues or information

Closes

<!-- Link to relevant issues, comments, etc. -->
