### PR TITLE
ci(github_actions): change default branch for github_actions execution

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -2,7 +2,7 @@ name: Build and Deploy
 on:
   push:
     branches:
-      - master
+      - website/master
 jobs:
   build-and-deploy:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Please remember the / Bitte beachte die [Contribution Guidelines](https://github.com/FUB-HCC/20-SWP-CodingOpenness/blob/master/CONTRIBUTION.md) :heart:

## What does this PR do?

- change default branch for github_actions execution

<!-- Concise description of what this PR achieves, including any context. -->

## Recommendations for testing

<!-- Tips for testing this PR, or anything you want to bring special attention to. -->

## Links to relevant issues or information

Closes

<!-- Link to relevant issues, comments, etc. -->
