### PR TITLE
Website/feature/about page styling stats

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -38,6 +38,10 @@ class App extends React.Component {
     activeContent: Content.HOME,
   };
 
+  componentDidUpdate() {
+    window.scrollTo(0, 0)
+  }
+
   handleNavbarClick = (activeContent) => {
     this.setState({ activeContent });
     history.push(activeContent);

--- a/src/Components/API/GithubAPI.css
+++ b/src/Components/API/GithubAPI.css
@@ -1,0 +1,12 @@
+.stat_wrapper {
+    width: 300px;
+    overflow: hidden;
+    padding-left: 10px;
+}
+.stat_value {
+    width: 30px;
+    float:left;
+}
+.stat_title {
+    overflow: hidden; 
+}

--- a/src/Components/API/GithubAPI.js
+++ b/src/Components/API/GithubAPI.js
@@ -1,0 +1,80 @@
+import React, { Component } from "react";
+
+import "./GithubAPI.css"
+
+const DATA_CACHE = {};
+
+const repoLink = "repos/FUB-HCC/20-SWP-CodingOpenness"
+const userLink = "users/FUB-HCC"
+
+class GithubAPI extends Component {
+  constructor() {
+    super();
+    this.state = { data: [] };
+  }
+
+  async load ()
+  {
+    if(DATA_CACHE[this.props.subLink] !== undefined)
+    {
+        this.setState({data: DATA_CACHE[this.props.subLink]})
+    }
+    else
+    {
+        var pageID = 1;
+        while(true)
+        {
+            const fetchLink = `https://api.github.com/${this.props.repoFetch ? repoLink : userLink}/${this.props.subLink}&page=${pageID}`
+            const response = await fetch(fetchLink);
+            const json = await response.json();
+
+            if(json === undefined || json.length === undefined)
+            {
+                DATA_CACHE[this.props.subLink] = 0;
+                break;
+            }
+            
+            if(json.length === 0)
+            {
+                break;
+            }
+
+            if(this.props.parseFunction != null)
+            {
+                DATA_CACHE[this.props.subLink] = this.props.parseFunction(DATA_CACHE[this.props.subLink], json);
+            }
+
+            pageID++;
+        }
+
+        this.setState({ data: DATA_CACHE[this.props.subLink] });
+    }
+  }
+
+  async componentDidMount() {
+      this.load();
+  }
+
+  async componentDidUpdate(prevPorps) 
+  {
+      if(prevPorps.subLink !== this.props.subLink)
+      {
+        this.load();
+      }
+  }
+
+  render() {
+    return (
+      <div className="stat_wrapper">
+          <div className="stat_value">
+            {this.state.data}
+          </div>
+          <div className="stat_title">
+            {this.props.title}
+          </div>
+      </div>
+    );
+  }
+}
+
+export default GithubAPI;

--- a/src/Components/API/GithubAPI.js
+++ b/src/Components/API/GithubAPI.js
@@ -15,7 +15,7 @@ class GithubAPI extends Component {
 
   async load ()
   {
-    if(DATA_CACHE[this.props.subLink] !== undefined)
+    if(DATA_CACHE[this.props.subLink] != null)
     {
         this.setState({data: DATA_CACHE[this.props.subLink]})
     }
@@ -28,7 +28,7 @@ class GithubAPI extends Component {
             const response = await fetch(fetchLink);
             const json = await response.json();
 
-            if(json === undefined || json.length === undefined)
+            if(json == null || json.length == null)
             {
                 DATA_CACHE[this.props.subLink] = 0;
                 break;

--- a/src/Components/About/About.css
+++ b/src/Components/About/About.css
@@ -1,10 +1,16 @@
 .about-container {
   padding: 30px;
 }
-.about-second-container {
+.about-first-container {
   display: flex;
   padding: 150px;
   padding-bottom: 0;
+}
+.about-second-container {
+  display: flex;
+  padding-left: 150px;
+  padding-bottom: 150px;
+  padding-right:150px;
 }
 .about-main {
   font-size: medium;

--- a/src/Components/About/About.css
+++ b/src/Components/About/About.css
@@ -16,6 +16,13 @@
   padding: 40px;
 }
 
+.about-first-main-stats {
+  font-size: medium;
+  width: 50%;
+  padding: 40px;
+}
+
+
 .about-second-main {
   font-size: medium;
   width: 50%;
@@ -54,15 +61,27 @@
   .about-container {
     padding: 0;
   }
-  .about-second-container {
+  .about-first-container {
     display: block;
     padding: 0;
+  }
+  .about-second-container {
+    display: block;
+    padding: 0 0 100px 0;
   }
   .about-member-container {
     display: block;
     padding: 10px 20px 100px 20px;
   }
-  .about-main {
+  .about-second-main {
+    width: 100%;
+    padding: 10px 0 0 0;
+  }
+  .about-first-main-stats {
+    width: 100%;
+    padding: 10px 0 0 0;
+  }
+  .about-first-main {
     width: 100%;
     padding: 80px 0 0 0;
   }

--- a/src/Components/About/About.css
+++ b/src/Components/About/About.css
@@ -8,20 +8,26 @@
 }
 .about-second-container {
   display: flex;
-  padding-left: 150px;
-  padding-bottom: 150px;
-  padding-right:150px;
+  padding: 0px 150px 150px 150px;
 }
-.about-main {
+.about-first-main {
   font-size: medium;
   width: 50%;
   padding: 40px;
 }
+
+.about-second-main {
+  font-size: medium;
+  width: 50%;
+  padding: 0px 40px 40px 40px;
+}
+
 .about-member-container {
   display: flex;
   justify-content: space-between;
   padding: 0px 210px 200px;
 }
+
 .abschnitt {
   padding: 5px 20px;
   font-weight: 500;

--- a/src/Components/About/About.js
+++ b/src/Components/About/About.js
@@ -72,7 +72,7 @@ class About extends React.Component {
       <>
         <div className={"about-container"}>
           <div className={"about-first-container"}>
-            <div className={"about-main"}>
+            <div className={"about-first-main"}>
               <div
                 style={{ fontSize: 50, fontWeight: 800 }}
                 className={"abschnitt"}
@@ -105,7 +105,7 @@ class About extends React.Component {
               </div>
             </div>
 
-            <div className={"about-main"}>
+            <div className={"about-first-main"}>
               <br />
               <br />
               <br />
@@ -156,7 +156,7 @@ class About extends React.Component {
 
           </div>
           <div className={"about-second-container"}>
-            <div className={"about-main"}>
+            <div className={"about-second-main"}>
               <div className="abschnitt">
                 {this.getGroupMemberList([
                   {
@@ -217,7 +217,7 @@ class About extends React.Component {
               </div>
             </div>
 
-            <div className={"about-main"}>
+            <div className={"about-second-main"}>
               <div className="abschnitt">
                 {this.getGroupMemberList([
                   {

--- a/src/Components/About/About.js
+++ b/src/Components/About/About.js
@@ -105,7 +105,7 @@ class About extends React.Component {
               </div>
             </div>
 
-            <div className={"about-first-main"}>
+            <div className={"about-first-main-stats"}>
               <br />
               <br />
               <br />

--- a/src/Components/About/About.js
+++ b/src/Components/About/About.js
@@ -248,7 +248,7 @@ class About extends React.Component {
                   {
                     name: "Felix Sekul",
                     groups:
-                      "Team Fragebogen, PEPP-PT, Corona-Warn-App: Exposure Logging",
+                      "Team Fragebogen, PEPP-PT, Corona-Warn-App: Exposure Logging, Data Privacy Information",
                     githubLink: "molpremotone",
                   },
                   {

--- a/src/Components/About/About.js
+++ b/src/Components/About/About.js
@@ -1,12 +1,45 @@
 import React from "react";
+import GithubAPI from "../API/GithubAPI";
+
 import { Icon } from "@blueprintjs/core";
 import "./About.css";
+
+const REPO_ID = 254040556;
 
 class About extends React.Component {
   componentDidMount() {
     if (this.props.handleNavbarClick != null) {
       this.props.handleNavbarClick();
     }
+  }
+
+  getSum = (lastSum, json) => {
+    return (
+      lastSum !== undefined
+        ? lastSum 
+        : 0)
+      + json.length;
+  };
+
+  getRepoWatchers = (lastStars, json) => {
+    return this.getRepoCountStats(lastStars, json, "watchers_count")
+  }
+
+  getRepoStars = (lastStars, json) => {
+    return this.getRepoCountStats(lastStars, json, "stargazers_count")
+  }
+
+  getRepoCountStats = (lastCount, json, type) => {
+    for(let key in json)
+    {
+      if(json[key]["id"] === REPO_ID)
+      {
+        return json[key][type];
+      }
+    }
+
+    return lastCount !== undefined ? lastCount : 0;
+
   }
 
   getMember(link, name, groups) {
@@ -38,7 +71,7 @@ class About extends React.Component {
     return (
       <>
         <div className={"about-container"}>
-          <div className={"about-second-container"}>
+          <div className={"about-first-container"}>
             <div className={"about-main"}>
               <div
                 style={{ fontSize: 50, fontWeight: 800 }}
@@ -71,118 +104,172 @@ class About extends React.Component {
                 und zu erweitern.`}
               </div>
             </div>
-          </div>
-          <div className={"about-member-container"}>
-            <div>
-              {this.getGroupMemberList([
-                {
-                  name: "Oussama Bouanani",
-                  groups: "Team Webseite, DP-3T",
-                  githubLink: "OussamaBouanani",
-                },
-                {
-                  name: "Johannes Brose",
-                  groups: "Team Technik, PEPP-PT, Corona-Warn-App: UI Design",
-                  githubLink: "JohBrose",
-                },
-                {
-                  name: "Julius Brose",
-                  groups:
-                    "Team Technik, DCTS, Corona-Warn-App: Risk of Infection",
-                  githubLink: "JuliusBro",
-                },
-                {
-                  name: "Keno Wilhelm Budde",
-                  groups: "Team Organisation, DP-3T",
-                  githubLink: "Clearwood",
-                },
-                {
-                  name: "Son Tung Duong",
-                  groups: "Team Webseite, DP-3T",
-                  githubLink: "sontungg",
-                },
-                {
-                  name: "Claas Fandre",
-                  groups:
-                    "Team Vergleich, Team Fragebogen, DCTS, Corona Warn App: Data Privacy Information",
-                  githubLink: "erdanf",
-                },
-                {
-                  name: "Linus Helfmann",
-                  groups:
-                    "Team Vergleich, Team Fragebogen, PEPP-PT, Corona Warn App: Data Privacy Information",
-                  githubLink: "linuxhelf",
-                },
-                {
-                  name: "Long Dang Pham Hoang",
-                  groups:
-                    "Team Technik, PEPP-PT, Corona-Warn-App: Risk of Infection",
-                  githubLink: "DPHLong",
-                },
-                {
-                  name: "Omer Hod",
-                  groups: "Team Webseite, DP-3T",
-                  githubLink: "Hod04",
-                },
-                {
-                  name: "Torben Knaak",
-                  groups: "Team Fragebogen, DCTS",
-                  githubLink: "eagle-seagull",
-                },
-              ])}
+
+            <div className={"about-main"}>
+              <br />
+              <br />
+              <br />
+              <div className="abschnitt">
+                <a
+                  href="https://github.com/FUB-HCC/20-SWP-CodingOpenness"
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className={"github-repo"}
+                >
+                  <img
+                    className="img-responsive"
+                    src={require("../../Assets/github.svg")}
+                    alt="20-SWP-CodingOpenness Repo"
+                  />
+                  20-SWP-CodingOpenness
+                </a>
+              </div>
+
+              <div className="abschnitt">
+                <GithubAPI 
+                repoFetch={false}
+                subLink='repos?'
+                title="Stars"
+                parseFunction={this.getRepoStars} />
+
+                <GithubAPI 
+                repoFetch={true}
+                subLink='contributors?' 
+                title="Contributors"
+                parseFunction={this.getSum} />
+
+                <GithubAPI 
+                repoFetch={true}
+                subLink='commits?'
+                title="Commits (master)"
+                parseFunction={this.getSum} />
+
+                <GithubAPI 
+                repoFetch={true}
+                subLink='commits?sha=website/master'
+                title="Commits (website/master)"
+                parseFunction={this.getSum} />
+              </div>
+
             </div>
 
-            <div>
-              {this.getGroupMemberList([
-                {
-                  name: "Viktoriya Kraleva",
-                  groups: "Team Vergleich, PEPP-PT, Corona-Warn-App: UI Design",
-                  githubLink: "kraleva",
-                },
-                {
-                  name: "Adriana Pinto Diaz Luz",
-                  groups: "Team Organisation, DP-3T",
-                  githubLink: "adrianapintod",
-                },
-                {
-                  name: "Dennis Nikolaus Natusch",
-                  groups: "Team Technik, DP-3T, Corona-Warn-App: UI Design",
-                  githubLink: "dennisn00",
-                },
-                {
-                  name: "David Paulini",
-                  groups: "Team Fragebogen, PEPP-PT",
-                  githubLink: "pada1015",
-                },
-                {
-                  name: "Bernd Sahre",
-                  groups: "Team Vergleich, Team Fragebogen, DCTS",
-                  githubLink: "bernd961",
-                },
-                {
-                  name: "Felix Sekul",
-                  groups:
-                    "Team Fragebogen, PEPP-PT, Corona-Warn-App: Exposure Logging",
-                  githubLink: "molpremotone",
-                },
-                {
-                  name: "Ingrid Tchilibou",
-                  groups:
-                    "Team Fragebogen, PEPP-PT, Corona-Warn-App: Exposure Logging",
-                  githubLink: "gancia-kiss",
-                },
-                {
-                  name: "Di Wang",
-                  groups: "Team Webseite, PEPP-PT",
-                  githubLink: "tratond01",
-                },
-                {
-                  name: "Julia Zimmermann",
-                  groups:
-                    "Team Vergleich, Team Fragebogen, DP-3T, Corona-Warn-App: Data Privacy Information",
-                  githubLink: "julizet",
-                },
-              ])}
+
+          </div>
+          <div className={"about-second-container"}>
+            <div className={"about-main"}>
+              <div className="abschnitt">
+                {this.getGroupMemberList([
+                  {
+                    name: "Oussama Bouanani",
+                    groups: "Team Webseite, DP-3T",
+                    githubLink: "OussamaBouanani",
+                  },
+                  {
+                    name: "Johannes Brose",
+                    groups: "Team Technik, PEPP-PT, Corona-Warn-App: UI Design",
+                    githubLink: "JohBrose",
+                  },
+                  {
+                    name: "Julius Brose",
+                    groups:
+                      "Team Technik, DCTS, Corona-Warn-App: Risk of Infection",
+                    githubLink: "JuliusBro",
+                  },
+                  {
+                    name: "Keno Wilhelm Budde",
+                    groups: "Team Organisation, DP-3T",
+                    githubLink: "Clearwood",
+                  },
+                  {
+                    name: "Son Tung Duong",
+                    groups: "Team Webseite, DP-3T",
+                    githubLink: "sontungg",
+                  },
+                  {
+                    name: "Claas Fandre",
+                    groups:
+                      "Team Vergleich, Team Fragebogen, DCTS, Corona Warn App: Data Privacy Information",
+                    githubLink: "erdanf",
+                  },
+                  {
+                    name: "Linus Helfmann",
+                    groups:
+                      "Team Vergleich, Team Fragebogen, PEPP-PT, Corona Warn App: Data Privacy Information",
+                    githubLink: "linuxhelf",
+                  },
+                  {
+                    name: "Long Dang Pham Hoang",
+                    groups:
+                      "Team Technik, PEPP-PT, Corona-Warn-App: Risk of Infection",
+                    githubLink: "DPHLong",
+                  },
+                  {
+                    name: "Omer Hod",
+                    groups: "Team Webseite, DP-3T",
+                    githubLink: "Hod04",
+                  },
+                  {
+                    name: "Torben Knaak",
+                    groups: "Team Fragebogen, DCTS",
+                    githubLink: "eagle-seagull",
+                  },
+                ])}
+              </div>
+            </div>
+
+            <div className={"about-main"}>
+              <div className="abschnitt">
+                {this.getGroupMemberList([
+                  {
+                    name: "Viktoriya Kraleva",
+                    groups: "Team Vergleich, PEPP-PT, Corona-Warn-App: UI Design",
+                    githubLink: "kraleva",
+                  },
+                  {
+                    name: "Adriana Pinto Diaz Luz",
+                    groups: "Team Organisation, DP-3T",
+                    githubLink: "adrianapintod",
+                  },
+                  {
+                    name: "Dennis Nikolaus Natusch",
+                    groups: "Team Technik, DP-3T, Corona-Warn-App: UI Design",
+                    githubLink: "dennisn00",
+                  },
+                  {
+                    name: "David Paulini",
+                    groups: "Team Fragebogen, PEPP-PT",
+                    githubLink: "pada1015",
+                  },
+                  {
+                    name: "Bernd Sahre",
+                    groups: "Team Vergleich, Team Fragebogen, DCTS",
+                    githubLink: "bernd961",
+                  },
+                  {
+                    name: "Felix Sekul",
+                    groups:
+                      "Team Fragebogen, PEPP-PT, Corona-Warn-App: Exposure Logging",
+                    githubLink: "molpremotone",
+                  },
+                  {
+                    name: "Ingrid Tchilibou",
+                    groups:
+                      "Team Fragebogen, PEPP-PT, Corona-Warn-App: Exposure Logging",
+                    githubLink: "gancia-kiss",
+                  },
+                  {
+                    name: "Di Wang",
+                    groups: "Team Webseite, PEPP-PT",
+                    githubLink: "tratond01",
+                  },
+                  {
+                    name: "Julia Zimmermann",
+                    groups:
+                      "Team Vergleich, Team Fragebogen, DP-3T, Corona-Warn-App: Data Privacy Information",
+                    githubLink: "julizet",
+                  },
+                ])}
+              </div>
             </div>
           </div>
         </div>

--- a/src/Components/CoronaWarnApp/CoronaWarnApp.js
+++ b/src/Components/CoronaWarnApp/CoronaWarnApp.js
@@ -201,7 +201,6 @@ val weightedAttenuationHigh =
 Es gibt des Weiteren, keine Abstufungen beim Ergebnis: Der Risk Score ist am Ende nichts weiteres, als eine gewichtete Zeit. Liegt diese über 15 Minuten, wird der Benutzer als ein Benutzer mit erhöhtem Risiko eingestuft, er wird benachrichtigt und weitere Handlungen werden ihm nahgelegt.
 
 Diese Informationen finden sich in der offiziellen`}
-
               <a
                 className={"about-inst-link"}
                 href={
@@ -212,7 +211,6 @@ Diese Informationen finden sich in der offiziellen`}
               >
                 Doku
               </a>
-
               {`.
               Weitere Dokumentation über`}
               <a
@@ -226,6 +224,18 @@ Diese Informationen finden sich in der offiziellen`}
                 Transmission risk level
               </a>
               {`.`}
+              Mehr Informationen zu unserer technischen Dokumentation finden Sie
+              auf unserer
+              <a
+                className={"about-inst-link"}
+                href={
+                  "https://github.com/FUB-HCC/20-SWP-CodingOpenness/wiki/Technik"
+                }
+                target="_blank"
+                rel="noopener noreferrer"
+              >
+                Github WikiSeite.
+              </a>
             </p>
           </div>
         </div>

--- a/src/Components/Fragebogen/Fragebogen.js
+++ b/src/Components/Fragebogen/Fragebogen.js
@@ -37,6 +37,19 @@ class Fragebogen extends React.Component {
               Ihre Sicht auf die App zu erhalten.
             </p>
             <p>Wir würden uns freuen, wenn Sie Teil unserer Umfrage werden.</p>
+            <p>
+              Unseren Arbeitsprozess zur Erstellung des Fragebogens haben wir in
+              diesem
+              <a
+                className={"about-inst-link"}
+                href="https://docs.google.com/document/d/1xE8mFtOHbUfDgn5mYqJlrYkR_ifVdNwq4jWIvNrXq4Y/edit#heading=h.pa46fv1rxmvq"
+                target="_blank"
+                rel="noopener noreferrer"
+              >
+                Dokument
+              </a>
+              ausführlich beschrieben.
+            </p>
             <a
               className={"fragebogen-link"}
               href="https://userpage.fu-berlin.de/~torbek32/umfrage/limesurvey/index.php/984297?lang=de"

--- a/src/Components/TeamContribution/TeamContribution.js
+++ b/src/Components/TeamContribution/TeamContribution.js
@@ -109,6 +109,27 @@ class TeamContribution extends React.Component {
                 </p>
               </div>
             </div>
+            <div className="boxed">
+              <div className="boxhead">
+                <p>
+                  <a
+                    className="fragebogen-link"
+                    href="https://github.com/adrianapintod/open-source-project-guidelines"
+                    target="_blank"
+                    rel="noopener noreferrer"
+                  >
+                    Open-Source Project Guidelines
+                  </a>
+                  <br /> by Keno Wilhelm Budde and Adriana Pinto Diaz Luz
+                </p>
+              </div>
+              <div>
+                <p>
+                  Open-Source Project Guidelines Richtlinien und Best Practices
+                  zur Arbeit an einem Open-Source Softwareprojekt.
+                </p>
+              </div>
+            </div>
           </div>
         </div>
       </>


### PR DESCRIPTION
##  What does this PR do?

- Adds GitHub repo stats to the About page.
- Fixes the styling issues in the About page.
- Fixes the scrolling view issue whenever a new view is loaded (scrolling level now gets reset to the top left every time).


## Recommendations for testing

- Check the About page.
- Attempt scrolling down in one of the pages then load another page.

## Links to relevant issues or information

None.
